### PR TITLE
doc: update Nils Ponsard's email adress

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,6 @@
 * Markus Meissner <meissner@nitrokey.com>
 * Markus Merklinger <markus@nitrokey.com>
 * Lucas Pluvinage <lucas@tarides.com>
-* Nils Ponsard <nils@nitrokey.com>
+* Nils Ponsard <nilsponsard@gmail.com>
 * Stefanie Schirmer <sschirme@gmail.com>
 * Jan Suhr <jan@nitrokey.com>


### PR DESCRIPTION
As I don't have access to the Nitrokey address anymore I prefer to be contacted at nilsponsard@gmail.com